### PR TITLE
#16 sops download and add to path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     mv kubectl /usr/local/bin
 
 ARG SOPS_VERSION=3.8.0
-RUN curl -L "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o "/usr/local/bin/sops" && \
+RUN curl --connect-timeout 30 --retry 5 -L "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o "/usr/local/bin/sops" && \
     chmod +x /usr/local/bin/sops
     
 FROM python:3-slim-bullseye

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,8 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     mv kubectl /usr/local/bin
 
 ARG SOPS_VERSION=3.8.0
-RUN curl -L "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o "/tmp/sops.linux.amd64" && \
-    mv "/tmp/sops.linux.amd64" /usr/local/bin/sops && \
-    chmod +x /usr/local/bin/sops && \
-    rm -rf "/tmp/sops.linux.amd64"
+RUN curl -L "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o "/usr/local/bin/sops" && \
+    chmod +x /usr/local/bin/sops
     
 FROM python:3-slim-bullseye
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl && \
     mv kubectl /usr/local/bin
 
+ARG SOPS_VERSION=3.8.0
+RUN curl -LO "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" && \
+    mv "sops-v${SOPS_VERSION}.linux.amd64" /usr/local/bin/sops && \
+    chmod +x /usr/local/bin/sops 
+    
 FROM python:3-slim-bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -33,6 +38,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=builder /usr/local/aws-cli /usr/local/aws-cli
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=builder /usr/local/bin/sops /usr/local/bin/sops
 
 RUN ln -s /usr/local/aws-cli/v2/current/dist/aws /usr/local/bin/aws && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,10 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     mv kubectl /usr/local/bin
 
 ARG SOPS_VERSION=3.8.0
-RUN curl -LO "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" && \
-    mv "sops-v${SOPS_VERSION}.linux.amd64" /usr/local/bin/sops && \
-    chmod +x /usr/local/bin/sops 
+RUN curl -L "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" -o "/tmp/sops.linux.amd64" && \
+    mv "/tmp/sops.linux.amd64" /usr/local/bin/sops && \
+    chmod +x /usr/local/bin/sops && \
+    rm -rf "/tmp/sops.linux.amd64"
     
 FROM python:3-slim-bullseye
 


### PR DESCRIPTION
Scope of changes:

1. Dockerfile: downloaded the sops file & make it executable in builder environment
2. Copy from builder env to container env.

Testing:

1. Locally run `make build`
2. Execute in the container and run `sops -h`. Verified that the sops cli tool was called successfully: 
<img width="715" alt="Screenshot 2023-09-26 at 3 18 11 pm" src="https://github.com/harrison-ai/cobalt-docker-terraform/assets/125983218/346e178d-a8ff-42e8-b29d-d16f3a13f060">
