### PR TITLE
Feature/add tflint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     mv kubectl /usr/local/bin
 
 ARG TFLINT_VERSION=0.48.0
-RUN curl -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip && \
+RUN curl --connect-timeout 30 --retry 5 -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip && \
     unzip -q /tmp/tflint.zip -d /tmp && \
     install -c -v /tmp/tflint /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
 ARG TFLINT_VERSION=0.48.0
 RUN curl -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip && \
     unzip -q /tmp/tflint.zip -d /tmp && \
-    install -c -v /tmp/tflint /usr/local/bin/
+    install -c -v /tmp/tflint /usr/local/bin/ && \
+    rm -rf /tmp/tflint /tmp/tflint.zip
 
 FROM python:3-slim-bullseye
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl && \
     mv kubectl /usr/local/bin
 
+ARG TFLINT_VERSION=0.48.0
+RUN curl -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip && \
+    unzip -q /tmp/tflint.zip -d /tmp && \
+    install -c -v /tmp/tflint /usr/local/bin/
+
 FROM python:3-slim-bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -33,6 +38,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY --from=builder /usr/local/bin/terraform /usr/local/bin/terraform
 COPY --from=builder /usr/local/aws-cli /usr/local/aws-cli
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=builder /usr/local/bin/tflint /usr/local/bin/tflint
 
 RUN ln -s /usr/local/aws-cli/v2/current/dist/aws /usr/local/bin/aws && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
 ARG TFLINT_VERSION=0.48.0
 RUN curl -L "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip" -o /tmp/tflint.zip && \
     unzip -q /tmp/tflint.zip -d /tmp && \
-    install -c -v /tmp/tflint /usr/local/bin/ && \
-    rm -rf /tmp/tflint /tmp/tflint.zip
+    install -c -v /tmp/tflint /usr/local/bin/
 
 FROM python:3-slim-bullseye
 


### PR DESCRIPTION
Changes are only in Dockerfile:

1. Download tflint zip, unzip and move to path of builder env.
2. Copy from builder path to container path

Testing

1. Run `make build` locally, `docker run` container and exec into container, run `tflint -v`. 
<img width="538" alt="Screenshot 2023-09-26 at 4 34 03 pm" src="https://github.com/harrison-ai/cobalt-docker-terraform/assets/125983218/0f7a50fc-8072-4219-bce2-34479c40603f">
Tested with downgraded tflint version too to ensure downgrading the TFLINT_VERSION arg works.

Note: recommended download method is via this shell script (https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh) however it requires a github token, so decided to manually install, as the other packages are also manually installed.