### PR TITLE
Update Terraform and AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-get update \
   unzip && \
   rm -rf /var/lib/apt/lists/*
 
-ARG TERRAFORM_VERSION=1.5.1
+ARG TERRAFORM_VERSION=1.6.2
 RUN curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o /tmp/terraform.zip && \
     unzip -q /tmp/terraform.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/terraform && \
     rm -f /tmp/terraform.zip
 
-ARG AWS_VERSION=2.12.3
+ARG AWS_VERSION=2.13.30
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_VERSION}.zip" -o "/tmp/awscliv2.zip" && \
     unzip -q /tmp/awscliv2.zip -d /tmp && \
     /tmp/aws/install && \


### PR DESCRIPTION
- Update Terraform

- Update AWS CLI to gain access to the `--enforce-security-group-inbound-rules-on-private-link-traffic` argument in the `aws elbv2 set-security-groups` command.